### PR TITLE
python-lsp-server 1.3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,8 @@ requirements:
     - yapf
 
 test:
+  imports:
+    - pylsp
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-lsp-server" %}
-{% set version = "1.2.4" %}
+{% set version = "1.3.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 007278c4419339bd3a61ca6d7eb8648ead28b5f1b9eba3b6bae8540046116335
+  sha256: 1b48ccd8b70103522e8a8b9cb9ae1be2b27a5db0dfd661e7e44e6253ebefdc40
 
 build:
   number: 0
@@ -18,23 +18,25 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - autopep8
-    - flake8 >=3.8.0,<4.0.0
-    - jedi >=0.17.2,<0.19
+    - autopep8 >=1.6.0,<1.7.0
+    - flake8 >=4.0.0,<4.1.0
+    - jedi >=0.17.2,<0.19.0
     - mccabe >=0.6.0,<0.7.0
     - pluggy
     - python-lsp-jsonrpc >=1.0.0
-    - pycodestyle >=2.7.0,<2.8.0
+    - pycodestyle >=2.8.0,<2.9.0
     - pydocstyle >=2.0.0
-    - pyflakes >=2.3.0,<2.4.0
-    - pylint >=2.5.0,<2.10.0
+    - pyflakes >=2.4.0,<2.5.0
+    - pylint >=2.5.0
     - python >=3.6
     - rope >=0.10.5
     - setuptools >=39.0.0
-    - ujson >=3.0
+    - ujson >=3.0.0
     - yapf
 
 test:
@@ -54,7 +56,7 @@ about:
     A Python 3.6+ implementation of the Language Server Protocol
     making use of Jedi, pycodestyle, Pyflakes and YAPF.
   dev_url: https://github.com/python-lsp/python-lsp-server
-
+  doc_url: https://github.com/python-lsp/python-lsp-server/blob/develop/README.md
 extra:
   recipe-maintainers:
     - ccordoba12


### PR DESCRIPTION
Changelog: https://github.com/python-lsp/python-lsp-server/blob/v1.3.3/CHANGELOG.md
License: https://github.com/python-lsp/python-lsp-server/blob/v1.3.3/LICENSE
Requirements: https://github.com/python-lsp/python-lsp-server/blob/v1.3.3/setup.py

Actions:
1. Add missing setuptools and wheel
2. Fix python in host
3. Update pinnings for run dependencies
4. Add test/imports
5. Add doc_url