### PR TITLE
Update `Python-lsp-server` to Version `1.4.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-lsp-server" %}
-{% set version = "1.3.3" %}
+{% set version = "1.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1b48ccd8b70103522e8a8b9cb9ae1be2b27a5db0dfd661e7e44e6253ebefdc40
+  sha256: be7f83298af9f0951a93972cafc9db04fd7cf5c05f20812515275f0ba70e342f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pylsp = pylsp.__main__:main
@@ -23,6 +23,7 @@ requirements:
     - setuptools
     - wheel
   run:
+    - importlib-metadata <4.3  # flake8 requires an older version of importlib-metadata
     - autopep8 >=1.6.0,<1.7.0
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0


### PR DESCRIPTION

`python-lsp-server` version `1.4.1`
1. - [x] Check the upstream
    https://github.com/python-lsp/python-lsp-server/tree/v1.4.1
    
2. - [x] Check the pinnings

`pluggy>=1.0.0`
https://github.com/python-lsp/python-lsp-server/blob/v1.4.1/setup.cfg#L17


`setuptools>=39.0.0`
https://github.com/python-lsp/python-lsp-server/blob/v1.4.1/setup.cfg#L19

3. - [x] Check the changelogs
    https://github.com/python-lsp/python-lsp-server/blob/v1.4.1/CHANGELOG.md

    The changes mentioned were bug fixes and new features.
    
4. - [x] Additional research
    https://github.com/conda-forge/python-lsp-server-feedstock/issues

    There is only one open issue at the time of the review. It is a request to simplify the optional dependencies needed. This should not affect our ability to build the package. 

5. - [x] Verify the `dev_url`
    https://github.com/python-lsp/python-lsp-server
    
6. - [x] Verify the `doc_url`
    https://github.com/python-lsp/python-lsp-server/blob/develop/README.md
    
7. - [x] License is `spdx` compliant
    
8. - [x] License family is present
    
9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    
11. - [x] Verify if the package needs `wheel`
    
12. - [x] `pip` in the test section
    
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Private variables are not mentioned on the recipe For example: (_private_variable)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `python-lsp-server` to version `1.4.1`

