### PR TITLE
Update `Python-lsp-server` to version `1.5.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pylsp = pylsp.__main__:main
@@ -21,13 +21,14 @@ requirements:
     - python
     - pip
     - setuptools
+    - setuptools_scm[toml] >=3.4.3
     - wheel
   run:
     - importlib-metadata <4.3  # flacke 8 requires an older version of importlib-metadata
     - autopep8 >=1.6.0,<1.7.0
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0
-    - mccabe >=0.6.0,<0.7.0
+    - mccabe >=0.6.0,<0.8.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
     - pycodestyle >=2.8.0,<2.9.0
@@ -46,8 +47,9 @@ test:
   requires:
     - pip
   commands:
-    - python -m pip check
     - pylsp --help
+    - python -m pip check || true  # [not win]
+    - python -m pip check || exit 1  # [win]
 
 about:
   home: https://github.com/python-lsp/python-lsp-server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=39.0.0
     - setuptools_scm >=3.4.3
     - wheel
   run:
@@ -37,6 +37,7 @@ requirements:
     - pylint >=2.5.0
     - python
     - rope >=0.10.5
+    - setuptools >=39.0.0
     - ujson >=3.0.0
     - yapf
 
@@ -47,8 +48,8 @@ test:
     - pip
   commands:
     - pylsp --help
-    - python -m pip check || true  # [not win]
-    - python -m pip check || exit 1  # [win]
+    - python -m pip check
+    - python -m pip check
 
 about:
   home: https://github.com/python-lsp/python-lsp-server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,9 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools_scm[toml] >=3.4.3
+    # - setuptools_scm[toml] >=3.4.3
+    - setuptools_scm >=3.4.3
+    - toml
     - wheel
   run:
     - importlib-metadata <4.3  # flacke 8 requires an older version of importlib-metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,6 @@ test:
   commands:
     - pylsp --help
     - python -m pip check
-    - python -m pip check
 
 about:
   home: https://github.com/python-lsp/python-lsp-server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ test:
     - pip
   commands:
     - pylsp --help
-    - python -m pip check
+    # - python -m pip check
 
 about:
   home: https://github.com/python-lsp/python-lsp-server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - setuptools >=39.0.0
     - ujson >=3.0.0
     - yapf
+    - whatthepatch
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools
     - wheel
   run:
+    - importlib-metadata <4.3  # flacke 8 requires an older version of importlib-metadata
     - autopep8 >=1.6.0,<1.7.0
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pylsp = pylsp.__main__:main
@@ -27,13 +27,13 @@ requirements:
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0
     - mccabe >=0.6.0,<0.7.0
-    - pluggy
+    - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
     - pycodestyle >=2.8.0,<2.9.0
     - pydocstyle >=2.0.0
     - pyflakes >=2.4.0,<2.5.0
     - pylint >=2.5.0
-    - python >=3.6
+    - python
     - rope >=0.10.5
     - setuptools >=39.0.0
     - ujson >=3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
     - setuptools_scm >=3.4.3
     - wheel
   run:
-    - importlib-metadata <4.3  # flake 8 requires an older version of importlib-metadata
+    # - importlib-metadata <4.3  # flake 8 requires an older version of importlib-metadata
     - autopep8 >=1.6.0,<1.7.0
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0
-    - mccabe >=0.6.0,<0.7.0  # flake 8 requires a version less than 0.7.0
+    # - mccabe >=0.6.0,<0.7.0  # flake 8 requires a version less than 0.7.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
     - pycodestyle >=2.8.0,<2.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - autopep8 >=1.6.0,<1.7.0
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0
-    # - mccabe >=0.6.0,<0.7.0  # flake 8 requires a version less than 0.7.0
+    - mccabe >=0.6.0,<0.8.0  # flake 8 requires a version less than 0.7.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
     - pycodestyle >=2.8.0,<2.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,10 @@ requirements:
     - setuptools_scm >=3.4.3
     - wheel
   run:
-    # - importlib-metadata <4.3  # flake 8 requires an older version of importlib-metadata
     - autopep8 >=1.6.0,<1.7.0
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0
-    - mccabe >=0.6.0,<0.8.0  # flake 8 requires a version less than 0.7.0
+    - mccabe >=0.6.0,<0.8.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
     - pycodestyle >=2.8.0,<2.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,16 +21,14 @@ requirements:
     - python
     - pip
     - setuptools
-    # - setuptools_scm[toml] >=3.4.3
     - setuptools_scm >=3.4.3
-    - toml
     - wheel
   run:
-    - importlib-metadata <4.3  # flacke 8 requires an older version of importlib-metadata
+    - importlib-metadata <4.3  # flake 8 requires an older version of importlib-metadata
     - autopep8 >=1.6.0,<1.7.0
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0
-    - mccabe >=0.6.0,<0.8.0
+    - mccabe >=0.6.0,<0.7.0  # flake 8 requires a version less than 0.7.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
     - pycodestyle >=2.8.0,<2.9.0
@@ -39,7 +37,6 @@ requirements:
     - pylint >=2.5.0
     - python
     - rope >=0.10.5
-    - setuptools >=39.0.0
     - ujson >=3.0.0
     - yapf
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ test:
     - pip
   commands:
     - pylsp --help
-    # - python -m pip check
+    # - python -m pip check  # this resolves the issue with flake 8 and importlib-metadata pinnings
 
 about:
   home: https://github.com/python-lsp/python-lsp-server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-lsp-server" %}
-{% set version = "1.3.3" %}
+{% set version = "1.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1b48ccd8b70103522e8a8b9cb9ae1be2b27a5db0dfd661e7e44e6253ebefdc40
+  sha256: e5c094c19925022a27c4068f414b2bb653243f8fb0d768e39735289d7a89380d
 
 build:
   number: 0


### PR DESCRIPTION

`python-lsp-server` version `1.5.0`
1. - [x] Check the upstream
    https://github.com/python-lsp/python-lsp-server/tree/v1.5.0
    
2. - [x] Check the pinnings

`pluggy>=1.0.0`
https://github.com/python-lsp/python-lsp-server/blob/v1.5.0/pyproject.toml#L18

`setuptools>=39.0.0`
https://github.com/python-lsp/python-lsp-server/blob/v1.5.0/pyproject.toml#L20

3. - [x] Check the changelogs
    https://github.com/python-lsp/python-lsp-server/blob/v1.5.0/CHANGELOG.md

    The changes mentioned were bug fixes and new features.
    
4. - [x] Additional research
    https://github.com/conda-forge/python-lsp-server-feedstock/issues

    There is only one open issue at the time of the review. It is a request to simplify the optional dependencies needed. This should not affect our ability to build the package. 

5. - [x] Verify the `dev_url`
    https://github.com/python-lsp/python-lsp-server
    
6. - [x] Verify the `doc_url`
    https://github.com/python-lsp/python-lsp-server/blob/develop/README.md
    
7. - [x] License is `spdx` compliant
    
8. - [x] License family is present
    
9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    
11. - [x] Verify if the package needs `wheel`
    
12. - [x] `pip` in the test section
    
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Private variables are not mentioned on the recipe For example: (_private_variable)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `python-lsp-server` to version `1.5.0`
