### PR TITLE
update 1.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-lsp-server" %}
-{% set version = "1.5.0" %}
+{% set version = "1.7.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e5c094c19925022a27c4068f414b2bb653243f8fb0d768e39735289d7a89380d
+  sha256: 67473bb301f35434b5fa8b21fc5ed5fac27dc8a8446ccec8bae456af52a0aef6
 
 build:
   number: 0
@@ -24,7 +24,9 @@ requirements:
     - setuptools_scm >=3.4.3
     - wheel
   run:
+    - python
     - autopep8 >=1.6.0,<1.7.0
+    - docstring-to-markdown
     - flake8 >=4.0.0,<4.1.0
     - jedi >=0.17.2,<0.19.0
     - mccabe >=0.6.0,<0.8.0
@@ -34,7 +36,6 @@ requirements:
     - pydocstyle >=2.0.0
     - pyflakes >=2.4.0,<2.5.0
     - pylint >=2.5.0
-    - python
     - rope >=0.10.5
     - setuptools >=39.0.0
     - ujson >=3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - pyflakes >=2.5.0,<3.1.0
     - pylint >=2.5.0,<3.0.0
     - rope >=1.2.0
+    - toml
     - yapf <=0.32.0
     - whatthepatch >=1.0.2,<2.0.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,20 +27,19 @@ requirements:
     - python
     - autopep8 >=1.6.0,<1.7.0
     - docstring-to-markdown
-    - flake8 >=4.0.0,<4.1.0
+    - flake8 >=5.0.0,<7.0.0
     - jedi >=0.17.2,<0.19.0
-    - mccabe >=0.6.0,<0.8.0
+    - mccabe >=0.7.0,<0.8.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
-    - pycodestyle >=2.8.0,<2.9.0
-    - pydocstyle >=2.0.0
-    - pyflakes >=2.4.0,<2.5.0
-    - pylint >=2.5.0
-    - rope >=0.10.5
-    - setuptools >=39.0.0
+    - pycodestyle >=2.9.0,<2.11.0
+    - pydocstyle >=6.2.0,<6.4.0
+    - pyflakes >=2.5.0,<3.1.0
+    - pylint >=2.5.0,<3.0.0
+    - rope >=1.2.0
     - ujson >=3.0.0
     - yapf
-    - whatthepatch
+    - whatthepatch >=1.0.2,<2.0.0
 
 test:
   imports:
@@ -49,11 +48,14 @@ test:
     - pip
   commands:
     - pylsp --help
-    # - python -m pip check  # this resolves the issue with flake 8 and importlib-metadata pinnings
+    - python -m pip check || true  # [not win]
+    - python -m pip check || exit 1  # [win]
+    # this resolves the issue with flake 8 and importlib-metadata pinnings
 
 about:
   home: https://github.com/python-lsp/python-lsp-server
   license: MIT
+  license_url: https://github.com/python-lsp/python-lsp-server/blob/develop/LICENSE
   license_family: MIT
   license_file: LICENSE
   summary: An implementation of the Language Server Protocol for Python
@@ -62,6 +64,7 @@ about:
     making use of Jedi, pycodestyle, Pyflakes and YAPF.
   dev_url: https://github.com/python-lsp/python-lsp-server
   doc_url: https://github.com/python-lsp/python-lsp-server/blob/develop/README.md
+  doc_source_url: https://github.com/python-lsp/python-lsp-server/tree/develop/docs
 extra:
   recipe-maintainers:
     - ccordoba12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - pip
     - setuptools >=39.0.0
-    - setuptools_scm[toml]>=3.4.3
+    - setuptools_scm >=3.4.3
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
     - pycodestyle =2.10.0
-    - pydocstyle >=6.2.0,<6.4.0
+    - pydocstyle >=6.3.0,<6.4.0
     - pyflakes >=2.5.0,<3.1.0
     - pylint >=2.5.0,<3.0.0
     - rope >=1.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,24 +21,27 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=39.0.0
+    - setuptools >=61.2.0
     - setuptools_scm >=3.4.3
     - wheel
   run:
+  # Required Dependencies
     - python
-    - autopep8 >=1.6.0,<1.7.0
-    - docstring-to-markdown
-    - flake8 >=5.0.0,<7.0.0
     - jedi >=0.17.2,<0.19.0
-    - mccabe >=0.7.0,<0.8.0
-    - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
+    - pluggy >=1.0.0
+    - docstring-to-markdown
+    - ujson >=3.0.0
+    - setuptools >=39.0.0
+  # Optional Dependencies
+    - autopep8 >=1.6.0,<1.7.0
+    - flake8 >=5.0.0,<7.0.0
+    - mccabe >=0.7.0,<0.8.0
     - pycodestyle =2.10.0
     - pydocstyle >=6.3.0,<6.4.0
     - pyflakes >=2.5.0,<3.1.0
     - pylint >=2.5.0,<3.0.0
     - rope >=1.2.0
-    - ujson >=3.0.0
     - yapf <=0.32.0
     - whatthepatch >=1.0.2,<2.0.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - pylint >=2.5.0,<3.0.0
     - rope >=1.2.0
     - ujson >=3.0.0
-    - yapf
+    - yapf <=0.32.0
     - whatthepatch >=1.0.2,<2.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - pip
     - setuptools >=39.0.0
-    - setuptools_scm >=3.4.3
+    - setuptools_scm[toml]>=3.4.3
     - wheel
   run:
     - python
@@ -33,7 +33,6 @@ requirements:
     - mccabe >=0.7.0,<0.8.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
-    # - pycodestyle >=2.9.0,<2.11.0
     - pycodestyle =2.10.0
     - pydocstyle >=6.2.0,<6.4.0
     - pyflakes >=2.5.0,<3.1.0
@@ -57,7 +56,6 @@ test:
 about:
   home: https://github.com/python-lsp/python-lsp-server
   license: MIT
-  license_url: https://github.com/python-lsp/python-lsp-server/blob/develop/LICENSE
   license_family: MIT
   license_file: LICENSE
   summary: An implementation of the Language Server Protocol for Python
@@ -66,7 +64,6 @@ about:
     making use of Jedi, pycodestyle, Pyflakes and YAPF.
   dev_url: https://github.com/python-lsp/python-lsp-server
   doc_url: https://github.com/python-lsp/python-lsp-server/blob/develop/README.md
-  doc_source_url: https://github.com/python-lsp/python-lsp-server/tree/develop/docs
 extra:
   recipe-maintainers:
     - ccordoba12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
+  # flake8 is unavailable for python versions less than 3.8.
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pylsp = pylsp.__main__:main
@@ -32,7 +33,8 @@ requirements:
     - mccabe >=0.7.0,<0.8.0
     - pluggy >=1.0.0
     - python-lsp-jsonrpc >=1.0.0
-    - pycodestyle >=2.9.0,<2.11.0
+    # - pycodestyle >=2.9.0,<2.11.0
+    - pycodestyle =2.10.0
     - pydocstyle >=6.2.0,<6.4.0
     - pyflakes >=2.5.0,<3.1.0
     - pylint >=2.5.0,<3.0.0


### PR DESCRIPTION
# Version Bump to 1.7.1
[Upstream](https://github.com/python-lsp/python-lsp-server)
[Requirements](https://github.com/python-lsp/python-lsp-server/blob/develop/pyproject.toml#L33)
[Jira](https://anaconda.atlassian.net/browse/PKG-975)
## Changes
- Update checksum and version number
- Due to dependencies such as `flake8` not supporting `python` versions less than 3.8, a `skip: True` has been added. [See here](https://github.com/PyCQA/flake8/blob/7aed16dc0910bfe93887763a8dfc0000292dd1f3/setup.cfg#L41) for further dependency information.
- Added required dependencies and updated necessary pinnings
- added `pip check` testing