### PR TITLE
python-lsp-server 1.14.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 509c445fc667f41ffd3191cb7512a497bf7dd76c14ceb1ee2f6c13ebe71f9a6b
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - pylsp = pylsp.__main__:main
@@ -47,7 +47,7 @@ requirements:
     # pyflakes updated source code to support Python 3.14 in version 3.4.0
     # https://github.com/PyCQA/pyflakes/commit/e5d4ba166d3b9236ba2ece8ae1c66a99752a5666
     - pyflakes ==3.4.0  # [py==314]
-    - pylint >=3.1,<4
+    - pylint >=3.1,<4.1
     - rope >=1.11.0
     - yapf >=0.33.0
     - whatthepatch >=1.0.2,<2.0.0


### PR DESCRIPTION
python-lsp-server 1.14.0 

**Destination channel:** Defaults

### Links

- [PKG-14069]
- dev_url:        https://github.com/python-lsp/python-lsp-server
- conda_forge:    https://github.com/conda-forge/python-lsp-server-feedstock
- pypi:           https://pypi.org/project/python-lsp-server/1.14.0
- pypi inspector: https://inspector.pypi.io/project/python-lsp-server/1.14.0

### Explanation of changes:

- fix `pylint` pinning
- new build number


[PKG-14069]: https://anaconda.atlassian.net/browse/PKG-14069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ